### PR TITLE
feat: add producto CRUD

### DIFF
--- a/backend/src/adapters/productoAdapter.js
+++ b/backend/src/adapters/productoAdapter.js
@@ -1,0 +1,48 @@
+const productoRepository=require('../repositories/productoRepository');
+const getAll=async()=>{
+    try{
+        const productos=await productoRepository.getAll();
+        return productos || [];
+    }catch(error){
+        throw error;
+    }
+}
+const getById=async(id)=>{
+    try {
+        const producto=await productoRepository.getById(id);
+        return producto || [];
+    }catch(error){
+        throw error;
+    }
+}
+const create=async(data)=>{
+    try {
+        const newProducto=await productoRepository.create(data);
+        return newProducto || [];
+    }catch(error){
+        throw error;
+    }
+}
+const update=async(id,data)=>{
+    try {
+        const updatedProducto=await productoRepository.update(id,data);
+        return updatedProducto || [];
+    }catch(error){
+        throw error;
+    }
+}
+const deleteProducto=async(id)=>{
+    try {
+        await productoRepository.delete(id);
+        return;
+    }catch(error){
+        throw error;
+    }
+}
+module.exports={
+    getAll,
+    getById,
+    create,
+    update,
+    delete:deleteProducto
+}

--- a/backend/src/controllers/productoController.js
+++ b/backend/src/controllers/productoController.js
@@ -1,0 +1,93 @@
+const productoAdapter = require('../adapters/productoAdapter');
+
+const getAll = async (req, res, next) => {
+    try {
+        const productos = await productoAdapter.getAll()
+        res.status(200).json(productos)
+    } catch (error) {
+        console.log('Error in getAll: ', error.message)
+        res.status(500).json({
+            message: 'Error in getAll'
+        })
+
+    }
+}
+const getById = async (req, res, next) => {
+    try {
+        const id = req.params.id
+        const producto = await productoAdapter.getById(id)
+        res.status(200).json(producto)
+    } catch (error) {
+        console.log('Error in getById: ', error.message)
+        res.status(500).json({
+            message: 'Error in getById'
+        })
+    }
+}
+const create = async (req, res, next) => {
+    try {
+        const {
+            nombre,
+            descripcion,
+            precio,
+            stock
+        } = req.body
+        const productoData = {
+            nombre,
+            descripcion,
+            precio,
+            stock
+        }
+        const producto = await productoAdapter.create(productoData)
+        res.status(201).json(producto)
+    } catch (error) {
+        console.log('Error in create: ', error.message)
+        res.status(500).json({
+            message: 'Error in create'
+        })
+    }
+}
+const update = async (req, res, next) => {
+    try {
+        const id = req.params.id
+        const {
+            nombre,
+            descripcion,
+            precio,
+            stock
+        } = req.body
+        const productoData = {
+            nombre,
+            descripcion,
+            precio,
+            stock
+        }
+        const updatedProducto = await productoAdapter.update(id, productoData)
+        res.status(200).json(updatedProducto)
+    } catch (error) {
+        console.log('Error in update: ', error.message)
+        res.status(500).json({
+            message: 'Error in update'
+        })
+    }
+}
+const deleteProducto = async (req, res, next) => {
+    try {
+        const id = req.params.id
+        await productoAdapter.delete(id)
+        res.status(204).send()
+    } catch (error) {
+        console.log('Error in delete: ', error.message)
+        res.status(500).json({
+            message: 'Error in delete'
+        })
+    }
+}
+
+module.exports={
+    getAll,
+    getById,
+    create,
+    update,
+    delete:deleteProducto
+}

--- a/backend/src/middleware/validaciones/producto.js
+++ b/backend/src/middleware/validaciones/producto.js
@@ -1,0 +1,48 @@
+const {
+    body,
+    validationResult
+} = require('express-validator');
+
+const productoValidationRules = () => {
+    return [
+        body('nombre')
+            .notEmpty()
+            .withMessage('El nombre es requerido').isLength({ min: 2, max: 255 })
+            .withMessage('El nombre debe tener entre 2 y 255 caracteres'),
+        body('descripcion')
+            .notEmpty()
+            .withMessage('La descripcion es requerida').isLength({ min: 5, max: 255 })
+            .withMessage('La descripcion debe tener entre 5 y 255 caracteres'),
+        body('precio')
+            .notEmpty()
+            .withMessage('El precio es requerido')
+            .isFloat({ gt: 0 })
+            .withMessage('El precio debe ser un número positivo'),
+        body('stock')
+            .notEmpty()
+            .withMessage('El stock es requerido')
+            .isInt({ min: 0 })
+            .withMessage('El stock debe ser un número entero no negativo'),
+    ];
+}
+const validate = (req, res, next) => {
+    const errors = validationResult(req)
+    console.log('errors', errors);
+    if (errors.isEmpty()) {
+        return next()
+    }
+    const extractedErrors = [];
+    errors.array().map(err => extractedErrors.push({
+        [err.path]: err.msg
+    }))
+
+
+    return res.status(422).json({
+        errors: extractedErrors,
+    })
+}
+
+module.exports = {
+    productoValidationRules,
+    validate,
+}

--- a/backend/src/migrations/20250914010734-create-producto.js
+++ b/backend/src/migrations/20250914010734-create-producto.js
@@ -1,0 +1,37 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Productos', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      nombre: {
+        type: Sequelize.STRING
+      },
+      descripcion: {
+        type: Sequelize.STRING
+      },
+      precio: {
+        type: Sequelize.DECIMAL
+      },
+      stock: {
+        type: Sequelize.INTEGER
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Productos');
+  }
+};

--- a/backend/src/models/producto.js
+++ b/backend/src/models/producto.js
@@ -1,0 +1,26 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Producto extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  }
+  Producto.init({
+    nombre: DataTypes.STRING,
+    descripcion: DataTypes.STRING,
+    precio: DataTypes.DECIMAL,
+    stock: DataTypes.INTEGER
+  }, {
+    sequelize,
+    modelName: 'Producto',
+  });
+  return Producto;
+};

--- a/backend/src/repositories/productoRepository.js
+++ b/backend/src/repositories/productoRepository.js
@@ -1,0 +1,58 @@
+const db=require('../models');
+const Producto=db.Producto;
+
+const getAll=async()=>{
+    try {
+        const productos=await Producto.findAll();
+        return productos;
+    } catch (error) {
+        throw error;
+    }
+}
+const getById=async(id)=>{
+    try {
+        const producto=await Producto.findByPk(id);
+        return producto;
+    } catch (error) {
+        throw error;
+    }
+}
+const create=async(data)=>{
+    try {
+        const newProducto=await Producto.create(data);
+        return newProducto;
+    } catch (error) {
+        throw error;
+    }
+}
+const update=async(id,data)=>{
+    try {
+        const producto=await Producto.findByPk(id);
+        if(!producto){
+            throw new Error('Producto not found');
+        }
+        const updatedProducto=await producto.update(data);
+        return updatedProducto;
+    } catch (error) {
+        throw error;
+    }
+}
+const deleteProducto=async(id)=>{
+    try {
+        const producto=await Producto.findByPk(id);
+        if(!producto){
+            throw new Error('Producto not found');
+        }
+        await producto.destroy();
+        return;
+    } catch (error) {
+        throw error;
+    }
+}
+module.exports={
+    getAll,
+    getById,
+    create,
+    update,
+    delete:deleteProducto
+}

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -4,11 +4,12 @@ const router = Router();
 // Importing auth routes
 const authRoutes = require('./auth.routes')
 const clienteRoutes = require('./cliente.routes')
+const productoRoutes = require('./producto.routes')
 
 
 // Using auth routes with a prefix
 router.use('/api/v1/auth', authRoutes);
 router.use('/api/v1/clientes', clienteRoutes);
-
+router.use('/api/v1/productos', productoRoutes);
 
 module.exports = router;

--- a/backend/src/routes/producto.routes.js
+++ b/backend/src/routes/producto.routes.js
@@ -1,0 +1,13 @@
+const express = require('express')
+const productoController = require('../controllers/productoController');
+const { verifyToken } = require("../middleware/index");
+const {productoValidationRules, validate} = require("../middleware/validaciones/producto");
+
+const router = express.Router();
+
+router.get('/', verifyToken,productoController.getAll);
+router.get('/:id', verifyToken,productoController.getById);
+router.post('/', [verifyToken,productoValidationRules(),validate],productoController.create);
+router.put('/:id',[verifyToken,productoValidationRules(),validate], productoController.update);
+router.delete('/:id',verifyToken, productoController.delete);
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Producto model, migration, repository, adapter and controller
- wire up producto routes with validation and auth middleware

## Testing
- `npx sequelize-cli db:migrate --config src/config/config.js --migrations-path src/migrations --models-path src/models` *(fails: ERROR)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6150d7454832fac68813a7fbf9b95